### PR TITLE
BS-14643 - stop using window.top.location and use window.parent.location instead

### DIFF
--- a/src/manage-top-url/manage-top-url.js
+++ b/src/manage-top-url/manage-top-url.js
@@ -7,27 +7,27 @@
 
       manageTopUrlService.getCurrentPageToken = function() {
         var pageTokenRegExp = /(^|[&\?])_p=([^&]*)(&|$)/,
-          pageTokenMatches = pageTokenRegExp.exec($window.top.location.hash);
+          pageTokenMatches = pageTokenRegExp.exec($window.parent.location.hash);
 
         return Array.isArray(pageTokenMatches) ? pageTokenMatches[2] : '';
       };
 
       manageTopUrlService.addOrReplaceParam = function (param, paramValue) {
 
-        if (paramValue !== undefined && $window.self !== $window.top) {
+        if (paramValue !== undefined && $window.self !== $window.parent) {
 
           var pageToken = manageTopUrlService.getCurrentPageToken();
 
-          if (!!$window.top.location.hash) {
+          if (!!$window.parent.location.hash) {
 
             var paramRegExp  = new RegExp('(^|[&\\?])'+pageToken+param+'=[^&]*(&|$)'),
-                paramMatches = $window.top.location.hash.match(paramRegExp);
+                paramMatches = $window.parent.location.hash.match(paramRegExp);
 
             if (!Array.isArray(paramMatches)) {
 
-              var currentHash = $window.top.location.hash;
+              var currentHash = $window.parent.location.hash;
               if(paramValue) {
-                $window.top.location.hash += ((currentHash.indexOf('&', currentHash.length - 2) >= 0) ? '' : '&') + pageToken + param + '=' + paramValue;
+                $window.parent.location.hash += ((currentHash.indexOf('&', currentHash.length - 2) >= 0) ? '' : '&') + pageToken + param + '=' + paramValue;
               }
 
             } else {
@@ -37,32 +37,32 @@
                 paramToSet = pageToken + param + '=' + paramValue;
               }
 
-              $window.top.location.hash = $window.top.location.hash.replace(paramRegExp, '$1'+ paramToSet + '$2');
+              $window.parent.location.hash = $window.parent.location.hash.replace(paramRegExp, '$1'+ paramToSet + '$2');
             }
             return;
 
           }
 
           if(paramValue) {
-            $window.top.location.hash = '#' + pageToken + param + '=' + paramValue;
+            $window.parent.location.hash = '#' + pageToken + param + '=' + paramValue;
           }
 
         }
       };
 
       manageTopUrlService.getCurrentProfile = function () {
-        if ($window && $window.top && $window.top.location && $window.top.location.hash) {
-          var currentProfileMatcher = $window.top.location.hash.match(/\b_pf=\d+\b/);
+        if ($window && $window.parent && $window.parent.location && $window.parent.location.hash) {
+          var currentProfileMatcher = $window.parent.location.hash.match(/\b_pf=\d+\b/);
           return Array.isArray(currentProfileMatcher) ? currentProfileMatcher[0] : '';
         }
       };
 
       manageTopUrlService.getPath = function () {
-        return $window.top.location.pathname;
+        return $window.parent.location.pathname;
       };
 
       manageTopUrlService.getSearch = function () {
-        return $window.top.location.search || '';
+        return $window.parent.location.search || '';
       };
 
       manageTopUrlService.getUrlToTokenAndId = function (id, token) {
@@ -82,7 +82,7 @@
           throw new TypeError('You must pass an Object as argument');
         }
         if(typeof destination === 'string'){
-          $window.top.location.hash = '?_p='+ destination+'&' + manageTopUrlService.getCurrentProfile();
+          $window.parent.location.hash = '?_p='+ destination+'&' + manageTopUrlService.getCurrentProfile();
           return;
         }
         var prependToken = !angular.isDefined(destination.prependToken) || !!destination.prependToken;
@@ -98,8 +98,8 @@
         });
 
         // Change the iframe hash only, not the current window hash
-        if($window.top.location.hash !== $window.location.hash) {
-          $window.top.location.hash = '?_p='+ destination.token+'&' + manageTopUrlService.getCurrentProfile() + params;
+        if($window.parent.location.hash !== $window.location.hash) {
+          $window.parent.location.hash = '?_p='+ destination.token+'&' + manageTopUrlService.getCurrentProfile() + params;
         }
       };
 

--- a/test/manage-top-url/manage-top-url.spec.js
+++ b/test/manage-top-url/manage-top-url.spec.js
@@ -9,7 +9,7 @@
 
     beforeEach(function(){
       mockedWindow = {
-        top : {
+        parent : {
           location:{
              hash: ''
           }
@@ -35,7 +35,7 @@
       });
 
       it('should return the search value in top url', function() {
-        mockedWindow.top.location.search = 'tome=1&tape=3';
+        mockedWindow.parent.location.search = 'tome=1&tape=3';
         mockedWindow.location.search = 'page_id=2';
         expect(manageTopUrl.getSearch()).toBe('tome=1&tape=3');
       });
@@ -46,8 +46,8 @@
 
       beforeEach(function () {
         spyOn(manageTopUrl, 'getCurrentProfile').and.returnValue('_pf=2');
-        mockedWindow.top.location.pathname = '/bonita/portal/homepage';
-        mockedWindow.top.location.search = '?tenant=1';
+        mockedWindow.parent.location.pathname = '/bonita/portal/homepage';
+        mockedWindow.parent.location.search = '?tenant=1';
       });
 
       it('should change top location hash to case detail', function () {
@@ -70,74 +70,74 @@
 
       it('should handle border cases', function(){
 
-        delete mockedWindow.top.location.hash;
+        delete mockedWindow.parent.location.hash;
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('#_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('#_tab=archived');
 
-        mockedWindow.top.location.hash = '_p=cases&tenant=1&';
+        mockedWindow.parent.location.hash = '_p=cases&tenant=1&';
         manageTopUrl.addOrReplaceParam('_tab','');
-        expect(mockedWindow.top.location.hash).toBe('_p=cases&tenant=1&');
+        expect(mockedWindow.parent.location.hash).toBe('_p=cases&tenant=1&');
 
-        mockedWindow.top.location.hash = '_p=cases&tenant=1&cases_tab=pouet';
+        mockedWindow.parent.location.hash = '_p=cases&tenant=1&cases_tab=pouet';
         manageTopUrl.addOrReplaceParam('_tab','');
-        expect(mockedWindow.top.location.hash).toBe('_p=cases&tenant=1&');
+        expect(mockedWindow.parent.location.hash).toBe('_p=cases&tenant=1&');
 
-        mockedWindow.top.location.hash = '_p=cases&tenant=1&';
+        mockedWindow.parent.location.hash = '_p=cases&tenant=1&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('_p=cases&tenant=1&cases_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('_p=cases&tenant=1&cases_tab=archived');
 
-        mockedWindow.top.location.hash = '';
+        mockedWindow.parent.location.hash = '';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('#_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('#_tab=archived');
 
-        mockedWindow.self = mockedWindow.top;
-        mockedWindow.top.location.hash = 'test';
+        mockedWindow.self = mockedWindow.parent;
+        mockedWindow.parent.location.hash = 'test';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe(mockedWindow.self.location.hash);
-        expect(mockedWindow.top.location.hash).toBe('test');
+        expect(mockedWindow.parent.location.hash).toBe(mockedWindow.self.location.hash);
+        expect(mockedWindow.parent.location.hash).toBe('test');
 
         delete mockedWindow.self;
-        mockedWindow.top.location.hash = '_p=page&page_tab=archived';
+        mockedWindow.parent.location.hash = '_p=page&page_tab=archived';
         manageTopUrl.addOrReplaceParam('_tab','');
-        expect(mockedWindow.top.location.hash).toBe('_p=page&');
+        expect(mockedWindow.parent.location.hash).toBe('_p=page&');
 
-        mockedWindow.top.location.hash = '';
+        mockedWindow.parent.location.hash = '';
         manageTopUrl.addOrReplaceParam('_tab','');
-        expect(mockedWindow.top.location.hash).toBe('');
+        expect(mockedWindow.parent.location.hash).toBe('');
       });
 
       it('should set top location hash to archived tab', function () {
 
-        mockedWindow.top.location.hash = '_p=cases&tenant=1&';
+        mockedWindow.parent.location.hash = '_p=cases&tenant=1&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('_p=cases&tenant=1&cases_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('_p=cases&tenant=1&cases_tab=archived');
 
-        mockedWindow.top.location.hash = '&tenant=1&_p=cases&';
+        mockedWindow.parent.location.hash = '&tenant=1&_p=cases&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('&tenant=1&_p=cases&cases_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('&tenant=1&_p=cases&cases_tab=archived');
 
-        mockedWindow.top.location.hash = 'tenant=1';
+        mockedWindow.parent.location.hash = 'tenant=1';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('tenant=1&_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('tenant=1&_tab=archived');
       });
 
       it('should change top location hash to archived tab', function () {
 
-        mockedWindow.top.location.hash = '_p=cases&cases_tab=1&';
+        mockedWindow.parent.location.hash = '_p=cases&cases_tab=1&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('_p=cases&cases_tab=archived&');
+        expect(mockedWindow.parent.location.hash).toBe('_p=cases&cases_tab=archived&');
 
-        mockedWindow.top.location.hash = '&_p=cases&cases_tab=1';
+        mockedWindow.parent.location.hash = '&_p=cases&cases_tab=1';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('&_p=cases&cases_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('&_p=cases&cases_tab=archived');
 
-        mockedWindow.top.location.hash = 'cases_tab=1&_p=cases&';
+        mockedWindow.parent.location.hash = 'cases_tab=1&_p=cases&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('cases_tab=archived&_p=cases&');
+        expect(mockedWindow.parent.location.hash).toBe('cases_tab=archived&_p=cases&');
 
-        mockedWindow.top.location.hash = '&cases_tab=1&';
+        mockedWindow.parent.location.hash = '&cases_tab=1&';
         manageTopUrl.addOrReplaceParam('_tab','archived');
-        expect(mockedWindow.top.location.hash).toBe('&cases_tab=1&_tab=archived');
+        expect(mockedWindow.parent.location.hash).toBe('&cases_tab=1&_tab=archived');
 
       });
 
@@ -149,22 +149,22 @@
 
       it('should not throw error when no top or hash empty', function(){
         expect(manageTopUrl.getCurrentProfile()).toBeUndefined();
-        delete mockedWindow.top;
+        delete mockedWindow.parent;
         expect(manageTopUrl.getCurrentProfile()).toBeUndefined();
       });
 
       it('should find _pf=2 from top window', function(){
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=2');
 
-        mockedWindow.top.location.hash = '?_pf=372&_p=ng-caselistingadmin';
+        mockedWindow.parent.location.hash = '?_pf=372&_p=ng-caselistingadmin';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=372');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=452&_pf=6';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=452&_pf=6';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=452');
 
-        mockedWindow.top.location.hash = '_pf=122';
+        mockedWindow.parent.location.hash = '_pf=122';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=122');
       });
 
@@ -176,16 +176,16 @@
 
       it('should find the page token from top window\'s hash', function(){
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         expect(manageTopUrl.getCurrentPageToken()).toBe('ng-caselistingadmin');
 
-        mockedWindow.top.location.hash = '?_pf=372&_p=caselistingadmin';
+        mockedWindow.parent.location.hash = '?_pf=372&_p=caselistingadmin';
         expect(manageTopUrl.getCurrentPageToken()).toBe('caselistingadmin');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselisting&_pf=452&_pf=6';
+        mockedWindow.parent.location.hash = '?_p=ng-caselisting&_pf=452&_pf=6';
         expect(manageTopUrl.getCurrentPageToken()).toBe('ng-caselisting');
 
-        mockedWindow.top.location.hash = '_pf=122';
+        mockedWindow.parent.location.hash = '_pf=122';
         expect(manageTopUrl.getCurrentPageToken()).toBe('');
       });
 
@@ -206,63 +206,63 @@
       });
 
       it('should use destination as token if it is a string', function() {
-        mockedWindow.top.location.hash = '?_p=sdfsdf&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=sdfsdf&_pf=2';
         manageTopUrl.goTo('caselistingadmin');
-        expect(mockedWindow.top.location.hash).toEqual('?_p=caselistingadmin&_pf=2');
+        expect(mockedWindow.parent.location.hash).toEqual('?_p=caselistingadmin&_pf=2');
       });
 
       it('should change top window\'s hash', function(){
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin'});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_pf=456';
+        mockedWindow.parent.location.hash = '?_pf=456';
         manageTopUrl.goTo({'token' : 'caselistingpm'});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingpm&_pf=456&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingpm&_pf=456&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin'});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', 'toto':undefined});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', '_toto': 'tata'});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&caselistingadmin_toto=tata&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&caselistingadmin_toto=tata&');
       });
 
       it('should not update the window.location if we are not inside an iframe', function() {
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', '_toto': 'tata'});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&caselistingadmin_toto=tata&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&caselistingadmin_toto=tata&');
         expect(mockedWindow.location.hash).toBe('#/home');
 
       });
       it('should change top window\'s hash without prepending token', function(){
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin',prependToken : false});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_pf=456';
+        mockedWindow.parent.location.hash = '?_pf=456';
         manageTopUrl.goTo({'token' : 'caselistingpm', prependToken : false});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingpm&_pf=456&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingpm&_pf=456&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', prependToken : false});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', 'toto':undefined, prependToken : false});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&');
 
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         manageTopUrl.goTo({'token' : 'caselistingadmin', 'toto': 'tata', prependToken : false});
-        expect(mockedWindow.top.location.hash).toBe('?_p=caselistingadmin&_pf=2&toto=tata&');
+        expect(mockedWindow.parent.location.hash).toBe('?_p=caselistingadmin&_pf=2&toto=tata&');
         //
       });
 


### PR DESCRIPTION
The goal of this PR is to be able to display the portal pages inside an IFrame without the top URL being changed every time you navigate. (see BS-14643).