### PR TITLE
fix(table-settings): add missing module dependency

### DIFF
--- a/src/table-settings/tableSettings.js
+++ b/src/table-settings/tableSettings.js
@@ -4,7 +4,8 @@
  */
 angular.module('org.bonitasoft.bonitable.settings', [
   'ui.bootstrap.dropdown',
-  'ui.bootstrap.buttons'
+  'ui.bootstrap.buttons',
+  'as.sortable'
   ])
 
   /**


### PR DESCRIPTION
Module dependency declaration was missing for as.sortable needed for column reordering